### PR TITLE
2.1.0

### DIFF
--- a/SYSTEM.md
+++ b/SYSTEM.md
@@ -65,16 +65,17 @@ A message can be a **string** (regular text message only) or a **table** (embed(
 
 The following message attributes in the `message` table structure are **currently being ignored / not supported** by the script:
 
-- `username`
-- `avatar_url`
-- `tts`
 - `allowed_mentions`
-- `components`
-- `files`
-- `payload_json`
-- `attachments`
 - `flags`
 - `thread_name`
+- `components` (*)
+- `files` (**)
+- `payload_json` (**)
+- `attachments` (**)
+
+(*) Requires an application-owned webhook.
+
+(**) See [Uploading Files (Discord API documentation)](https://discord.com/developers/docs/reference#uploading-files) for details.
 
 *Source: [Discord API documentation - Webhook JSON/Form Params](https://discord.com/developers/docs/resources/webhook#execute-webhook-jsonform-params)*
 

--- a/discord_webhooks/system.lua
+++ b/discord_webhooks/system.lua
@@ -10,6 +10,7 @@
 addEvent("discord_webhooks:send", true) -- source must always be root
 addEvent("discord_webhooks:sendToURL", true) -- source must always be root
 
+-- https://discord.com/developers/docs/resources/webhook#execute-webhook-jsonform-params
 local function internalValidateMessage(message)
 	local newMessage
 	if type(message) == "string" then
@@ -31,11 +32,34 @@ local function internalValidateMessage(message)
 			if message.embeds[1] == nil then
 				return false, "Invalid embeds: Expected table with at least one element OR one element directly, got empty table"
 			end
+			-- Check for additional message attributes
 			if message.content ~= nil then
 				if type(message.content) ~= "string" then
 					return false, "Invalid content: Expected string, got "..type(message.content)
 				end
 			end
+			if message.username ~= nil then
+				if type(message.username) ~= "string" then
+					return false, "Invalid username: Expected string, got "..type(message.username)
+				end
+			end
+			if message.avatar_url ~= nil then
+				if type(message.avatar_url) ~= "string" then
+					return false, "Invalid avatar_url: Expected string, got "..type(message.avatar_url)
+				end
+			end
+			if message.tts ~= nil then
+				if type(message.tts) ~= "boolean" then
+					return false, "Invalid tts: Expected boolean, got "..type(message.tts)
+				end
+			end
+			-- TODO:
+			-- 		allowed_mentions
+			-- 		flags
+			-- 		thread_name
+			-- 		components (require an application-owned webhook)
+			
+			-- File attachments (files[n], payload_json, attachments) will probably not be supported here
 		end
 		for i=1, #message.embeds do
 			local embed = message.embeds[i]


### PR DESCRIPTION
# Changes:

- Added info on missing message params (https://discord.com/developers/docs/resources/webhook#execute-webhook-jsonform-params)
- Now supports custom message username (string), avatar_url (string) and tts (boolean).